### PR TITLE
Remove unused include in utm.h

### DIFF
--- a/libs/UTM/include/UTM/UTM.h
+++ b/libs/UTM/include/UTM/UTM.h
@@ -24,7 +24,6 @@
 #include <cmath>
 #include <stdio.h>
 #include <stdlib.h>
-#include "ofMathConstants.h"
 
 
 namespace UTM


### PR DESCRIPTION
There was an unsued include in `UTM.h` called `ofMathConstants.h`

Seems like it is not needed in this file. So removing it

Hope it works :)